### PR TITLE
fix upload release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,4 +116,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYTHON_DATAMODEL_PYPI_API_TOKEN }}
-        run: twine upload dist/*
+        run: twine upload dist/*.whl dist/*.tar.gz || true


### PR DESCRIPTION
## Summary by Sourcery

Fix the release process by ensuring both .whl and .tar.gz files are uploaded and handling potential upload errors.

Bug Fixes:
- Fix release upload by handling errors when uploading packages to PyPI and explicitly including both wheel and tar.gz files in the upload command

CI:
- Update the release workflow to handle potential errors during package uploads