### PR TITLE
fix the _repr_ to avoid errors with a field fails to be converted int…

### DIFF
--- a/datamodel/models.py
+++ b/datamodel/models.py
@@ -155,8 +155,15 @@ class ModelMixin:
         return self.__columns__[name]
 
     def __repr__(self) -> str:
-        f_repr = ", ".join(f"{f.name}={getattr(self, f.name)}" for f in fields(self))
-        return f"{self.__class__.__name__}({f_repr})"
+        field_strs = []
+        for field_name in self.__fields__:
+            try:
+                value = getattr(self, field_name)
+            except AttributeError:
+                # If this field doesn't exist on the instance, ignore it
+                continue
+            field_strs.append(f"{field_name}={value!r}")
+        return f"{self.__class__.__name__}({', '.join(field_strs)})"
 
     def pop(self, key: str, default: Any = _MISSING_TYPE) -> Any:
         """

--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.5'
+__version__ = '0.10.6'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'

--- a/examples/test_dynamic.py
+++ b/examples/test_dynamic.py
@@ -1,0 +1,60 @@
+from typing import Optional, Any
+from dataclasses import InitVar
+from datamodel import BaseModel, Column
+from datamodel.exceptions import ValidationError
+
+class Identity(BaseModel):
+    """Identity.
+
+    Describe an Authenticated Entity on Navigator.
+    """
+
+    id: Any = Column(required=True)
+    auth_method: str = None
+    access_token: Optional[str] = None
+    enabled: bool = Column(required=True, default=True)
+    data: InitVar = {}
+    is_authenticated: bool = Column(equired=False, default=False)
+    userdata: dict = Column(required=False, default_factory=dict)
+
+    def __post_init__(self, data):  # pylint: disable=W0221
+        self.userdata = data
+        for key, value in data.items():
+            self.create_field(key, value)
+
+    def set(self, name: str, value: Any) -> None:
+        # alias for "create_field"
+        self.create_field(name, value)
+
+    class Meta:
+        strict = False
+        frozen = False
+
+
+class BaseUser(Identity):
+    name: str = Column(required=True)
+    email: str = Column(required=True)
+
+# Test the creation of dynamic fields on Datamodel:
+if __name__ == '__main__':
+    data = {
+        'id': 12345,
+        'name': 'John Doe',
+        'email': 'john.doe@example.com',
+        'age': 30,
+        'is_active': True,
+        'magic': 'Navigator',
+        'address': {
+            'street': '123 Main St',
+            'city': 'Anytown',
+            'state': 'NY',
+            'zip': '10001'
+        }
+    }
+    try:
+        user = BaseUser(data)
+        print(user)
+    except ValidationError as e:
+        print(e.payload)
+    except Exception as e:
+        print(e)


### PR DESCRIPTION
…o an string.

## Summary by Sourcery

Fixes a bug in the `__repr__` method that caused errors when a field could not be converted to a string, increments the package version, and adds a new example file to demonstrate dynamic fields.

New Features:
- Adds a new example file `test_dynamic.py` to demonstrate the creation of dynamic fields on Datamodel.

Bug Fixes:
- Fixes an error in the `__repr__` method that occurs when a field fails to be converted to a string.

Chores:
- Increments the package version to 0.10.6.