### PR TITLE
adding support to parse ObjectId bson objects into string and binary

### DIFF
--- a/datamodel/converters.pyx
+++ b/datamodel/converters.pyx
@@ -662,6 +662,12 @@ cpdef object parse_basic(object T, object data, object encoder = None):
                 raise ValueError(
                     f"Error parsing type {T}, {e}"
                 )
+            except AttributeError as e:
+                if data is None:
+                    return None
+                raise AttributeError(
+                    f"Attribute Error for Encoder {encoder!s} for type {T}: {e}"
+                ) from e
     # Using the encoders for basic types:
     try:
         return encoders[T](data)

--- a/datamodel/parsers/json.pyx
+++ b/datamodel/parsers/json.pyx
@@ -60,6 +60,13 @@ cdef inline bint is_subclassof(object obj, object cls):
         return False
     return res != 0
 
+cdef inline bint is_objid(object obj):
+    return (
+        getattr(obj, "__class__", None) is not None and
+        obj.__class__.__module__ == "bson.objectid" and
+        obj.__class__.__name__ == "ObjectId"
+    )
+
 
 ORJSON_DEFAULT_OPTIONS = (
     orjson.OPT_SERIALIZE_NUMPY |
@@ -122,6 +129,8 @@ cdef class JSONContent:
                 return obj.name
         elif isinstance(obj, Binary):  # Handle bytea column from PostgreSQL
             return str(obj)  # Convert Binary object to string
+        elif is_objid(obj):
+            return str(obj)
         elif isinstance(obj, Field):
             if has_attribute(obj, 'to_dict'):
                 return obj.to_dict()

--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.6'
+__version__ = '0.10.7'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'

--- a/examples/test_validations.py
+++ b/examples/test_validations.py
@@ -1,8 +1,10 @@
 from typing import Union, List
 import uuid
+from bson import ObjectId
 from datetime import datetime
-from datamodel import BaseModel, Column
+from datamodel import BaseModel, Column, Field
 from datamodel.exceptions import ValidationError
+
 
 
 def auto_uuid(*args, **kwargs):
@@ -65,10 +67,21 @@ user = {
     ]
 }
 
+def to_objid(value):
+    if isinstance(value, str):
+        return ObjectId(value.encode('ascii'))
+    return value
+
+class Dataset(BaseModel):
+    _id: ObjectId = Field(encoder=to_objid)
+    name: str = Field(required=True)
+
 
 if __name__ == '__main__':
     user = Actor(**user)
-    print(f"User: ID: {user.userid}, Name: {user.name}, age: {user.age}, accounts: {user.account!r}, created: {user.created_at}")
+    print(
+        f"User: ID: {user.userid}, Name: {user.name}, age: {user.age}, accounts: {user.account!r}, created: {user.created_at}"
+    )
     print(f'Types: {type(user.created_at)}')
     try:
         # Test if name is required:
@@ -120,3 +133,18 @@ if __name__ == '__main__':
         print(
             f"ValidationError: {ex.payload}"
         )
+    try:
+        print('================================================================')
+        dataset = Dataset(_id='123456789012', name="Test Dataset")
+        print(dataset._id, dataset.name)
+        print(' == Convert into JSON ===')
+        data = dataset.to_json()
+        print(data)
+        print(' == Revert Back ===')
+        d = Dataset(**dataset.to_dict())
+        print(d._id, type(d._id))
+    except ValidationError as ex:
+        print(f"Error: {ex}", type(ex))
+        print(f"ValidationError: {ex.payload}")
+    except ValueError as ex:
+        print(f"Error: {ex}", type(ex))


### PR DESCRIPTION
## Summary by Sourcery

Add support for parsing `ObjectId` BSON objects into strings and binary, and update the version of the datamodel library.

New Features:
- Add support for parsing `ObjectId` BSON objects into strings.
- Add support for parsing `ObjectId` BSON objects into binary.

Chores:
- Update the version of the datamodel library from 0.10.6 to 0.10.7.