### PR TITLE
fix issue with setuptools-rust version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     'setuptools==74.0.0',
     'Cython==3.0.11',
     'wheel==0.44.0',
-    "setuptools-rust>=1.10.2",
+    "setuptools-rust==1.10.2",
     'maturin>=1,<2',
     'typing-extensions >=4.6.0,!=4.7.0'
 ]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue with setuptools-rust version by pinning it to 1.10.2 in pyproject.toml.