### PR TITLE
avoid error confusing list of objects with foreign key objects

### DIFF
--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.9'
+__version__ = '0.10.10'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'


### PR DESCRIPTION
## Summary by Sourcery

Fixes an issue where a list of objects was being confused with foreign key objects during the conversion of BaseModel instances to their primary key value. This change ensures that lists of submodels are correctly handled during the __collapse_as_values__ conversion process, and that the schema builder correctly assigns fields.

Bug Fixes:
- Fixes an issue where a list of objects was being confused with foreign key objects.
- Ensures that lists of submodels are correctly handled during the __collapse_as_values__ conversion process.
- Fixes schema builder to correctly assign fields.

Chores:
- Updates the version to 0.10.10.