### PR TITLE
using ciso for iso-formatted datetimes to avoid dropping timezone inf…

### DIFF
--- a/datamodel/converters.pyx
+++ b/datamodel/converters.pyx
@@ -194,15 +194,16 @@ cpdef datetime.datetime to_datetime(object obj):
         except ValueError:
             pass
     try:
-        return rc.to_datetime(obj)
+        return ciso8601.parse_datetime(obj)
     except ValueError:
         pass
     try:
-        return ciso8601.parse_datetime(obj)
+        return rc.to_datetime(obj)
     except ValueError:
         raise ValueError(
             f"Can't convert invalid data *{obj}* to datetime"
         )
+
 
 cpdef object to_integer(object obj):
     """to_integer.

--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.13'
+__version__ = '0.10.14'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'

--- a/examples/timezone.py
+++ b/examples/timezone.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from datamodel import BaseModel, Field
+
+
+class DateTest(BaseModel):
+    date_field: datetime = Field(required=True)
+
+
+if __name__ == '__main__':
+    data = {'date_field': "2025-03-24T11:10:22-05:00"}
+    date_test = DateTest(**data)
+    print(date_test.date_field)
+    print(date_test.to_dict())
+    print(date_test.to_json())


### PR DESCRIPTION
…ormation

## Summary by Sourcery

Improve datetime parsing by using ciso8601 to handle ISO-formatted datetimes, ensuring timezone information is retained. Revert the order of the try-except block to prioritize ciso8601 parsing before falling back to the rs_parsers library. Add an example to showcase timezone handling.