### PR TITLE
fix compatibility for python 3.10

### DIFF
--- a/datamodel/parsers/json.pyx
+++ b/datamodel/parsers/json.pyx
@@ -25,7 +25,11 @@ from cpython.object cimport (
 from dataclasses import _MISSING_TYPE, MISSING, InitVar
 from typing import Any, Union
 from decimal import Decimal
-from enum import Enum, EnumType
+from enum import Enum
+try:
+    from enum import EnumType
+except ImportError:
+    from enum import EnumMeta as EnumType
 import orjson
 from ..exceptions cimport ParserError
 from ..fields import Field
@@ -71,7 +75,6 @@ cdef inline bint is_objid(object obj):
 ORJSON_DEFAULT_OPTIONS = (
     orjson.OPT_SERIALIZE_NUMPY |
     orjson.OPT_UTC_Z
-    # orjson.OPT_NON_STR_KEYS
 )
 
 

--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.17'
+__version__ = '0.10.18'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'

--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.18'
+__version__ = '0.10.19'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'


### PR DESCRIPTION
## Summary by Sourcery

Ensure compatibility with Python 3.10 while improving model serialization behavior and bumping the library version.

Bug Fixes:
- Handle EnumType import for Python 3.10+ by falling back to EnumMeta when EnumType is unavailable.
- Prevent internal and excluded fields, including the _pgoutput attribute, from being included in collapsed value dictionaries.

Enhancements:
- Extend model serialization helpers to accept an exclude set for more flexible field exclusion.
- Update the library version metadata to reflect the latest release.