### PR TITLE
fix an issue for building

### DIFF
--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.19'
+__version__ = '0.10.20'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,63 +1,92 @@
 [build-system]
 requires = [
-    'setuptools==74.0.0',
-    'Cython==3.0.11',
-    'wheel==0.44.0',
-    "setuptools-rust==1.10.2",
-    'maturin>=1,<2',
-    'typing-extensions >=4.6.0,!=4.7.0'
+    "setuptools>=74.0.0",
+    "setuptools_scm[toml]>=8.0",
+    "Cython==3.0.11",
+    "wheel>=0.44.0",
+    "setuptools-rust>=1.10.2",
+    "pip>=24.3.1"
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.flit.metadata]
-module = "python-datamodel"
-author = "Jesus Lara Gimenez"
-author-email = "jesuslarag@gmail.com"
-home-page = "https://github.com/phenobarbital/python-datamodel"
-classifiers=[
-  "Development Status :: 4 - Beta",
-  "Intended Audience :: Developers",
-  "Intended Audience :: System Administrators",
-  "Intended Audience :: Information Technology",
-  "Operating System :: OS Independent",
-  "Operating System :: POSIX :: Linux",
-  "Operating System :: Microsoft :: Windows",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python",
-  "Programming Language :: Rust",
-  "Typing :: Typed",
-  "Environment :: Web Environment",
-  "Framework :: AsyncIO",
-  "Topic :: Software Development :: Libraries :: Application Frameworks",
-  "Topic :: Software Development :: Libraries :: Python Modules",
-  "Topic :: Software Development :: Build Tools",
-  "License :: OSI Approved :: BSD License",
+[project]
+name = "python-datamodel"
+dynamic = ["version"]
+description = "simple library based on python +3.8 to use Dataclass-syntax for interacting with Data"
+authors = [
+    {name = "Jesus Lara", email = "jesuslarag@gmail.com"}
 ]
-dynamic = ['version', 'description', 'license', 'keywords', 'readme']
-description-file = "README.md"
+readme = "README.md"
+license = {text = "BSD"}
 requires-python = ">=3.10.0"
+keywords = ["asyncio", "dataclass", "dataclasses", "data models"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Framework :: AsyncIO",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Topic :: System :: Systems Administration",
+    "Topic :: Utilities",
+    "Environment :: Web Environment",
+]
 
-[tool.pytest.ini_options]
-addopts = [
-  "--strict-config",
-  "--strict-markers",
+dependencies = [
+    "numpy>=1.26.4",
+    "uvloop>=0.21.0",
+    "asyncio==3.4.3",
+    "faust-cchardet==2.1.19",
+    "ciso8601==2.3.2",
+    "objectpath==0.6.1",
+    "orjson>=3.10.11",
+    "typing_extensions>=4.9.0",
+    "asyncpg>=0.29.0",
+    "python-dateutil>=2.8.2",
+    "python-slugify==8.0.1",
+    "psycopg2-binary==2.9.10",
+    "msgspec==0.19.0"
 ]
-log_cli = true
-log_cli_level = "DEBUG"
-log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
-log_cli_date_format = "%Y-%m-%d %H:%M:%S"
-filterwarnings = [
-    "error",
-    'ignore:The loop argument is deprecated since Python 3\.8, and scheduled for removal in Python 3\.10:DeprecationWarning:asyncio',
-]
+
+[project.urls]
+Homepage = "https://github.com/phenobarbital/python-datamodel"
+Source = "https://github.com/phenobarbital/python-datamodel"
+Tracker = "https://github.com/phenobarbital/python-datamodel/issues"
+Documentation = "https://datamodel.readthedocs.io/en/latest/"
+Funding = "https://paypal.me/phenobarbital"
+"Say Thanks!" = "https://saythanks.io/to/phenobarbital"
+
+[tool.setuptools]
+license-files = ["LICENSE"]
+packages = ["datamodel"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"datamodel.fields" = ["*.pyx"]
+"datamodel.converters" = ["*.pyx"]
+"datamodel.validation" = ["*.pyx"]
+"datamodel.exceptions" = ["*.pxd", "*.pyx"]
+"datamodel.functions" = ["*.pxd", "*.pyx"]
+"datamodel.libs.mapping" = ["*.pxd", "*.pyx"]
+"datamodel.typedefs.singleton" = ["*.pxd", "*.pyx"]
+"datamodel.typedefs.types" = ["*.pxd", "*.pyx"]
+"datamodel.parsers.json" = ["*.pyx"]
+
+[tool.setuptools.dynamic]
+version = {attr = "datamodel.version.__version__"}
+
+
 
 [tool.black]
 line-length = 120
-target-version = [ 'py310', 'py311', 'py312', 'py313' ]
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -73,19 +102,26 @@ exclude = '''
 )/
 '''
 
-[tool.mypy]
-pretty = true
-ignore_missing_imports = true
+[tool.uv]
+override-dependencies = [
+    "setuptools-rust>=1.10.2",
+]
 
-[tool.flake8]
-ignore = 'E501,W503,E203'
-
-[tool.maturin]
-python-source = "datamodel/rs_parsers"
-module-name = "datamodel.rs_parsers"
-bindings = "pyo3"
-features = ["pyo3/extension-module"]
-
-[tool.cibuildwheel]
-build = "cp3{10,11,12,13}-*"
-skip = "pypy*"
+[tool.pytest.ini_options]
+addopts = [
+    "--strict-config",
+    "--strict-markers",
+]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"
+log_cli = true
+log_cli_level = "DEBUG"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+filterwarnings = [
+    "error",
+]
+markers = [
+    "asyncio: mark a test as a coroutine that should be run by pytest-asyncio",
+]

--- a/setup.py
+++ b/setup.py
@@ -5,49 +5,11 @@
 See:
 https://github.com/phenobarbital/DataModel
 """
-import ast
-from os import path
+
 
 from Cython.Build import cythonize
-from setuptools import Extension, find_packages, setup, find_namespace_packages
+from setuptools import Extension, setup
 from setuptools_rust import RustExtension
-
-
-def get_path(filename):
-    return path.join(path.dirname(path.abspath(__file__)), filename)
-
-
-def readme():
-    with open(get_path('README.md'), encoding='utf-8') as rd:
-        return rd.read()
-
-
-version = get_path('datamodel/version.py')
-with open(version, 'r', encoding='utf-8') as meta:
-    t = compile(meta.read(), version, 'exec', ast.PyCF_ONLY_AST)
-    for node in (n for n in t.body if isinstance(n, ast.Assign)):
-        if len(node.targets) == 1:
-            name = node.targets[0]
-            if isinstance(name, ast.Name) and \
-                    name.id in (
-                        '__version__',
-                        '__title__',
-                        '__description__',
-                        '__author__',
-                        '__license__', '__author_email__'):
-                v = node.value
-                if name.id == '__version__':
-                    __version__ = v.s
-                if name.id == '__title__':
-                    __title__ = v.s
-                if name.id == '__description__':
-                    __description__ = v.s
-                if name.id == '__license__':
-                    __license__ = v.s
-                if name.id == '__author__':
-                    __author__ = v.s
-                if name.id == '__author_email__':
-                    __author_email__ = v.s
 
 
 COMPILE_ARGS = ["-O3"]
@@ -127,84 +89,10 @@ extensions = [
 ]
 
 setup(
-    name="python-datamodel",
-    version=__version__,
-    python_requires=">=3.10.0",
-    url="https://github.com/phenobarbital/python-datamodel",
-    description=__description__,
-    keywords=['asyncio', 'dataclass', 'dataclasses', 'data models'],
-    platforms=['any'],
-    long_description=readme(),
-    long_description_content_type='text/markdown',
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: System Administrators",
-        "Topic :: Software Development :: Build Tools",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Framework :: AsyncIO",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Topic :: System :: Systems Administration",
-        "Topic :: Utilities",
-        "Environment :: Web Environment",
-    ],
-    author=__author__,
-    author_email=__author_email__,
-    packages=find_namespace_packages(exclude=["contrib", "docs", "tests", "examples"]),
-    include_package_data=True,
-    package_data={
-        "datamodel.fields": ["*.pyx"],
-        "datamodel.converters": ["*.pyx"],
-        "datamodel.validation": ["*.pyx"],
-        "datamodel.exceptions": ["*.pxd", "*.pyx"],
-        "datamodel.functions": ["*.pxd", "*.pyx"],
-        "datamodel.libs.mapping": ["*.pxd", "*.pyx"],
-        "datamodel.typedefs.singleton": ["*.pxd", "*.pyx"],
-        "datamodel.typedefs.types": ["*.pxd", "*.pyx"],
-        "datamodel.parsers.json": ["*.pyx"],
-    },
-    license=__license__,
-    setup_requires=[
-        'setuptools==74.0.0',
-        'Cython==3.0.11',
-        'wheel==0.44.0',
-        'pip>=24.3.1,<26.0',
-        'setuptools-rust==1.10.2',
-    ],
-    install_requires=[
-        "numpy>=1.26.4",
-        "uvloop>=0.21.0",
-        "asyncio==3.4.3",
-        "faust-cchardet==2.1.19",
-        "ciso8601==2.3.2",
-        "objectpath==0.6.1",
-        "orjson>=3.10.11",
-        'typing_extensions>=4.9.0',
-        "asyncpg>=0.29.0",
-        "python-dateutil>=2.8.2",
-        "python-slugify==8.0.1",
-        "psycopg2-binary==2.9.10",
-        "msgspec==0.19.0"
-    ],
     ext_modules=cythonize(
         extensions,
         annotate=True
     ),
     zip_safe=False,
     rust_extensions=rust_extensions,
-    project_urls={  # Optional
-        "Source": "https://github.com/phenobarbital/datamodel",
-        "Funding": "https://paypal.me/phenobarbital",
-        "Tracker": "https://github.com/phenobarbital/datamodel/issues",
-        "Documentation": "https://datamodel.readthedocs.io/en/latest/",
-        "Buy Me A Coffee!": "https://www.buymeacoffee.com/phenobarbital",
-        "Say Thanks!": "https://saythanks.io/to/phenobarbital",
-    },
 )


### PR DESCRIPTION
## Summary by Sourcery

Modernize package build and metadata configuration to rely on pyproject.toml instead of setup.py-driven metadata, and bump the library version.

New Features:
- Define project metadata, dependencies, and URLs using the PEP 621 [project] table in pyproject.toml.
- Configure setuptools package data for Cython and Rust-related modules via pyproject.toml.

Enhancements:
- Relax and update build-system requirements, adding setuptools_scm-based dynamic versioning and pip to the build dependencies.
- Streamline setup.py to only handle Cython and Rust extension building, delegating metadata and dependency management to pyproject.toml.
- Update pytest configuration to define test discovery patterns, strict settings, and asyncio marker usage in pyproject.toml.

Build:
- Switch to setuptools.build_meta with PEP 621 metadata and dynamic version configuration using datamodel.version.__version__.
- Add uv override configuration for setuptools-rust and remove legacy cibuildwheel and flit configuration.

Documentation:
- Link project documentation and funding URLs under the [project.urls] section in pyproject.toml.

Chores:
- Bump the package version from 0.10.19 to 0.10.20.