### PR TITLE
fix build for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Build wheels on Windows
         if: matrix.os == 'windows-latest'
+        env:
+          CIBW_BUILD: "cp3{10,11,12,13}-*"
         run: |
           pip install cibuildwheel maturin
           cibuildwheel --output-dir dist


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Configure the Windows release job to build wheels only for CPython 3.10–3.13 using cibuildwheel.