### PR TITLE
fix: make uvloop a non-Windows-only dependency

### DIFF
--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.20'
+__version__ = '0.10.21'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 
 dependencies = [
     "numpy>=1.26.4",
-    "uvloop>=0.21.0",
+    "uvloop>=0.21.0; sys_platform != 'win32'",
     "asyncio==3.4.3",
     "faust-cchardet==2.1.19",
     "ciso8601==2.3.2",


### PR DESCRIPTION
uvloop has no Windows support and aborts at build time with "uvloop does not support Windows". Declaring it unconditionally made any pip install on Windows fail while resolving dependencies. Add the 'sys_platform != win32' marker so Windows installs skip it.

Bump version to 0.10.21.

## Summary by Sourcery

Make uvloop an optional dependency on non-Windows platforms and bump the library version.

Bug Fixes:
- Prevent Windows installations from failing by skipping uvloop on win32 platforms.

Build:
- Add environment marker so uvloop is only installed on non-Windows systems.

Chores:
- Update package version to 0.10.21.