### PR TITLE
feat(new-infra-spec-uvloop-py314-windows): FEAT-001 — Optional uvloop, Python 3.14 build, Windows wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,15 @@ name: Python package build and publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - python-version: "3.10"
@@ -42,25 +45,27 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_ARCHS: x86_64
-          CIBW_BEFORE_BUILD: >-
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_BUILD: ${{ matrix.cibw-build }}
+          CIBW_ENVIRONMENT_LINUX: "PATH=/root/.cargo/bin:$PATH"
+          CIBW_BEFORE_BUILD_LINUX: >-
             curl https://sh.rustup.rs -sSf | sh -s -- -y &&
             export PATH=/root/.cargo/bin:$PATH &&
             pip install maturin &&
-            cd {project}/rust && rm -rf target/wheels &&
-            maturin build --release --manylinux off --interpreter python3
-            --manifest-path rs_parsers/Cargo.toml &&
-            python3 -c "import zipfile,glob,os,shutil;whl=glob.glob('target/wheels/*.whl')[0];zf=zipfile.ZipFile(whl);so=[n for n in zf.namelist() if n.endswith('.so') and '_rs_parsers' in n][0];zf.extract(so,'/tmp/_rs');shutil.copy2(os.path.join('/tmp/_rs',so),'{project}/datamodel/rs_parsers/')" &&
-            cd {project}
-          CIBW_ENVIRONMENT: "PATH=/root/.cargo/bin:$PATH"
-          CIBW_BUILD: ${{ matrix.cibw-build }}
+            python scripts/stage_rust_ext.py --manylinux off
+          CIBW_BEFORE_BUILD_WINDOWS: >-
+            pip install maturin &&
+            python scripts/stage_rust_ext.py
+          CIBW_TEST_COMMAND: >-
+            python -c "import datamodel.rs_parsers as r; assert r.HAS_RUST"
         run: |
-          cibuildwheel --platform linux --output-dir dist
+          cibuildwheel --output-dir dist
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-py${{ matrix.python-version }}
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
           path: dist/*.whl
 
   deploy:
@@ -79,7 +84,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4.1.7
         with:
-          pattern: wheels-py*
+          pattern: wheels-*
           path: dist-artifacts
           merge-multiple: true
 
@@ -100,6 +105,29 @@ jobs:
           if ls dist/*-manylinux*.whl 1> /dev/null 2>&1; then
             echo "Found manylinux wheels."
             echo "HAS_MANYLINUX_WHEELS=true" >> $GITHUB_ENV
+          fi
+
+      - name: Verify wheel inventory
+        run: |
+          set -e
+          echo "Checking dist/ for the expected wheel inventory..."
+          manylinux_count=$(ls dist/*-manylinux*_x86_64.whl 2>/dev/null | wc -l)
+          windows_count=$(ls dist/*-win_amd64.whl 2>/dev/null | wc -l)
+          sdist_count=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
+          echo "manylinux x86_64 wheels: $manylinux_count"
+          echo "win_amd64 wheels: $windows_count"
+          echo "sdist: $sdist_count"
+          if [ "$manylinux_count" -ne 5 ]; then
+            echo "ERROR: expected 5 manylinux x86_64 wheels (cp310-cp314), found $manylinux_count" >&2
+            exit 1
+          fi
+          if [ "$windows_count" -ne 5 ]; then
+            echo "ERROR: expected 5 win_amd64 wheels (cp310-cp314), found $windows_count" >&2
+            exit 1
+          fi
+          if [ "$sdist_count" -ne 1 ]; then
+            echo "ERROR: expected exactly one sdist, found $sdist_count" >&2
+            exit 1
           fi
 
       - name: List files in dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Add Rust to PATH
-        run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        shell: bash
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: |
@@ -48,6 +49,7 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
           CIBW_BUILD: ${{ matrix.cibw-build }}
+          CIBW_SKIP: "*-musllinux_*"
           CIBW_ENVIRONMENT_LINUX: "PATH=/root/.cargo/bin:$PATH"
           CIBW_BEFORE_BUILD_LINUX: >-
             curl https://sh.rustup.rs -sSf | sh -s -- -y &&
@@ -114,9 +116,11 @@ jobs:
           manylinux_count=$(ls dist/*-manylinux*_x86_64.whl 2>/dev/null | wc -l)
           windows_count=$(ls dist/*-win_amd64.whl 2>/dev/null | wc -l)
           sdist_count=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
+          total_wheel_count=$(ls dist/*.whl 2>/dev/null | wc -l)
           echo "manylinux x86_64 wheels: $manylinux_count"
           echo "win_amd64 wheels: $windows_count"
           echo "sdist: $sdist_count"
+          echo "total wheels: $total_wheel_count"
           if [ "$manylinux_count" -ne 5 ]; then
             echo "ERROR: expected 5 manylinux x86_64 wheels (cp310-cp314), found $manylinux_count" >&2
             exit 1
@@ -127,6 +131,12 @@ jobs:
           fi
           if [ "$sdist_count" -ne 1 ]; then
             echo "ERROR: expected exactly one sdist, found $sdist_count" >&2
+            exit 1
+          fi
+          # Guard against unexpected extra wheels (e.g. musllinux) slipping
+          # into dist/ and being uploaded unfiltered by the publish step.
+          if [ "$total_wheel_count" -ne 10 ]; then
+            echo "ERROR: expected exactly 10 wheels total (5 manylinux + 5 win_amd64), found $total_wheel_count" >&2
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.pyd
 
 # Distribution / packaging
 .Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Optional `python-datamodel[uvloop]` extra (`uvloop>=0.21.0; sys_platform != 'win32'`),
   and an explicit, opt-in `datamodel.libs.uvloop.install_uvloop()` helper. Importing
   `datamodel` never activates uvloop; callers invoke the helper themselves.
-* Python 3.14 wheels, verified end to end through the release workflow.
+* Python 3.14 build target added to the release workflow (pending a live
+  `workflow_dispatch` verification run before the first 0.11.0 release).
 * Windows (`win_amd64`) wheels for cp310-cp314, built with the Rust extension
   (`_rs_parsers*.pyd`) included; the release job fails if the Rust build fails.
 * `scripts/stage_rust_ext.py`, a cross-platform staging script (replaces the previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.11.0]
+
+### Added
+* Optional `python-datamodel[uvloop]` extra (`uvloop>=0.21.0; sys_platform != 'win32'`),
+  and an explicit, opt-in `datamodel.libs.uvloop.install_uvloop()` helper. Importing
+  `datamodel` never activates uvloop; callers invoke the helper themselves.
+* Python 3.14 wheels, verified end to end through the release workflow.
+* Windows (`win_amd64`) wheels for cp310-cp314, built with the Rust extension
+  (`_rs_parsers*.pyd`) included; the release job fails if the Rust build fails.
+* `scripts/stage_rust_ext.py`, a cross-platform staging script (replaces the previous
+  Linux-only inline extractor) used by both the release workflow and `make stage-rust`.
+* A `workflow_dispatch` trigger on `.github/workflows/release.yml` so the full build
+  matrix can be dry-run before cutting a release.
+
+### Changed
+* **Breaking**: `uvloop` is no longer installed automatically as a transitive dependency
+  of `python-datamodel`. Applications that relied on datamodel to pull in `uvloop` must
+  now request it explicitly via `pip install "python-datamodel[uvloop]"` (or install
+  `uvloop` themselves) and call `install_uvloop()`.
+* `setup.py` now selects MSVC-compatible compiler/link flags (`/O2`, no extra link args)
+  on `win32`, and keeps the existing `-O3` / `-lstdc++` flags on other platforms.
+* Both `[build-system].requires` and the `dev` extra now pin `Cython>=3.2.8`.
+
+### Notes
+* No macOS or ARM/aarch64 wheels are published; the release matrix remains manylinux
+  x86_64 + win_amd64.
+
 ## [0.0.15] - 2022-09-15
 * fixing building wheel for x86_64
 * fixing behaviors over Meta class in Models with missing attributes

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,4 +14,8 @@ jesuslara@lexotanil:~$ rustc --version
 rustc 1.84.0 (9fc6b4312 2025-01-07)
 
 # Install Setup dependencies:
-pip install cython maturin sdist setuptools wheel setuptools-rust
+pip install cython maturin sdist setuptools wheel
+
+# Build the Rust extension with Maturin and stage it into the source tree
+# so setuptools bundles it into the wheel:
+make stage-rust

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ build-rust:
 # extension.
 stage-rust:
 	python scripts/stage_rust_ext.py --manifest rust/rs_parsers/Cargo.toml \
-	  --dest datamodel/rs_parsers --out-dir $(RUST_WHEEL_OUT) --interpreter python
+	  --dest datamodel/rs_parsers --out-dir $(RUST_WHEEL_OUT) --interpreter python \
+	  --maturin-bin $(MATURIN)
 
 # ---- Cython ----
 

--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,8 @@ build-rust:
 # the source tree, so the wheel would otherwise ship without the Rust
 # extension.
 stage-rust:
-	$(MATURIN) build --release -i python --manifest-path rust/rs_parsers/Cargo.toml --out $(RUST_WHEEL_OUT)
-	@whl=$$(ls -t $(RUST_WHEEL_OUT)/rs_parsers-*.whl | head -1); \
-	  test -n "$$whl" || { echo "ERROR: maturin produced no wheel in $(RUST_WHEEL_OUT)"; exit 1; }; \
-	  echo "Staging Rust extension from $$whl"; \
-	  tmp=$$(mktemp -d); \
-	  unzip -o -q "$$whl" -d "$$tmp"; \
-	  find "$$tmp" -name '_rs_parsers*.so' -exec cp {} datamodel/rs_parsers/ \; ; \
-	  rm -rf "$$tmp"; \
-	  ls -la datamodel/rs_parsers/_rs_parsers*.so
+	python scripts/stage_rust_ext.py --manifest rust/rs_parsers/Cargo.toml \
+	  --dest datamodel/rs_parsers --out-dir $(RUST_WHEEL_OUT) --interpreter python
 
 # ---- Cython ----
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ The key features are:
 
 ## Requirements
 
-Python 3.8+
+Python 3.10+ (3.10, 3.11, 3.12, 3.13 and 3.14 are supported).
+
+Binary wheels are published for Linux (`manylinux` x86_64) and Windows
+(`win_amd64`); other platforms fall back to a source install.
 
 ## Installation
 
@@ -26,6 +29,24 @@ Successfully installed datamodel
 
 
 </div>
+
+### Optional uvloop acceleration
+
+`uvloop` is not a hard dependency: install it as the optional `uvloop`
+extra on supported non-Windows platforms:
+
+```console
+$ pip install "python-datamodel[uvloop]"
+```
+
+Importing `datamodel` never changes the application's event-loop policy.
+Opt in explicitly, typically at application startup:
+
+```python
+from datamodel.libs.uvloop import install_uvloop
+
+install_uvloop()
+```
 
 ## Quickstart
 

--- a/datamodel/libs/uvloop.py
+++ b/datamodel/libs/uvloop.py
@@ -15,10 +15,9 @@ On Python 3.12+, callers may prefer
 process-wide policy installed by this helper.
 """
 import sys
-from typing import Optional
 
 HAS_UVLOOP = False
-uvloop: Optional[object] = None
+uvloop: object | None = None
 
 try:
     import uvloop  # type: ignore[no-redef]

--- a/datamodel/libs/uvloop.py
+++ b/datamodel/libs/uvloop.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Optional uvloop activation helper.
+
+This module mirrors the optional-import pattern used by
+`datamodel.rs_parsers` (see `HAS_RUST`): `HAS_UVLOOP` reports whether the
+`uvloop` package is importable, and `install_uvloop()` is an explicit,
+opt-in helper that installs uvloop's event-loop policy.
+
+Nothing in `datamodel/__init__.py` imports this module, so importing
+`datamodel` never has any effect on the caller's event loop. Callers must
+invoke `install_uvloop()` themselves, typically at application startup.
+
+On Python 3.12+, callers may prefer
+`asyncio.run(main(), loop_factory=uvloop.new_event_loop)` instead of the
+process-wide policy installed by this helper.
+"""
+import sys
+from typing import Optional
+
+HAS_UVLOOP = False
+uvloop: Optional[object] = None
+
+try:
+    import uvloop  # type: ignore[no-redef]
+
+    HAS_UVLOOP = True
+except ImportError:
+    uvloop = None
+
+
+def install_uvloop() -> bool:
+    """Install uvloop as the asyncio event-loop policy.
+
+    Returns `True` when the policy was installed (or was already uvloop's).
+    Returns `False`, without raising, when uvloop is not importable or when
+    `sys.platform == "win32"`. Idempotent: calling it more than once is
+    always safe. Never called implicitly by `datamodel`.
+    """
+    if sys.platform == "win32" or not HAS_UVLOOP:
+        return False
+    uvloop.install()
+    return True

--- a/datamodel/version.py
+++ b/datamodel/version.py
@@ -6,7 +6,7 @@ __description__ = (
     'simple library based on python +3.8 to use Dataclass-syntax'
     'for interacting with Data'
 )
-__version__ = '0.10.21'
+__version__ = '0.11.0'
 __copyright__ = 'Copyright (c) 2020-2024 Jesus Lara'
 __author__ = 'Jesus Lara'
 __author_email__ = 'jesuslarag@gmail.com'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=74.0.0",
     "setuptools_scm[toml]>=8.0",
-    "Cython>=3.0.11",
+    "Cython>=3.2.8",
     "wheel>=0.44.0",
 ]
 build-backend = "setuptools.build_meta"
@@ -41,7 +41,6 @@ classifiers = [
 
 dependencies = [
     "numpy>=1.26.4",
-    "uvloop>=0.21.0; sys_platform != 'win32'",
     "faust-cchardet>=2.1.19",
     "ciso8601>=2.3.2",
     "objectpath>=0.6.1",
@@ -55,6 +54,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+uvloop = [
+    "uvloop>=0.21.0; sys_platform != 'win32'",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
@@ -62,7 +64,7 @@ dev = [
     "ruff>=0.6.0",
     "mypy>=1.0",
     "maturin>=1.7,<2.0",
-    "Cython>=3.0.11",
+    "Cython>=3.2.8",
     "setuptools>=74.0.0",
     "pydantic>=2.0",
     "PyYAML>=6.0",
@@ -78,7 +80,7 @@ Funding = "https://paypal.me/phenobarbital"
 
 [tool.setuptools]
 license-files = ["LICENSE"]
-packages = ["datamodel"]
+packages = ["datamodel", "datamodel.libs"]
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/scripts/stage_rust_ext.py
+++ b/scripts/stage_rust_ext.py
@@ -32,10 +32,17 @@ def build_wheel(
     out_dir: str,
     interpreter: str,
     manylinux: str | None,
+    maturin_bin: str = "maturin",
 ) -> int:
-    """Run `maturin build --release` for `manifest`, writing to `out_dir`."""
+    """Run `maturin build --release` for `manifest`, writing to `out_dir`.
+
+    `maturin_bin` defaults to the bare `"maturin"` command (resolved via
+    PATH, as CI does after `pip install maturin`), but accepts a full path
+    so callers such as `Makefile`'s `stage-rust` target can pin the exact
+    venv-local binary instead of relying on ambient PATH resolution.
+    """
     command = [
-        "maturin",
+        maturin_bin,
         "build",
         "--release",
         "--interpreter",
@@ -91,13 +98,14 @@ def main(
     out_dir: str = "rust/target/wheels",
     interpreter: str = "python",
     manylinux: str | None = None,
+    maturin_bin: str = "maturin",
 ) -> int:
     """Build the Rust extension and stage it into `dest`.
 
     Returns 0 on success. Returns non-zero when Maturin fails, no wheel is
     produced, or no `_rs_parsers*.so`/`.pyd` member is found in the wheel.
     """
-    return_code = build_wheel(manifest, out_dir, interpreter, manylinux)
+    return_code = build_wheel(manifest, out_dir, interpreter, manylinux, maturin_bin)
     if return_code != 0:
         print(f"ERROR: maturin build failed (exit {return_code})", file=sys.stderr)
         return return_code
@@ -145,6 +153,15 @@ def parse_args(argv: list[str] | None = None) -> dict:
         default=None,
         help="Value forwarded to `maturin build --manylinux` (e.g. 'off'); omitted when unset",
     )
+    parser.add_argument(
+        "--maturin-bin",
+        default="maturin",
+        help=(
+            "Maturin executable to invoke; pass a full path (e.g. "
+            "'.venv/bin/maturin') to pin a specific venv instead of "
+            "resolving 'maturin' via PATH (default: %(default)s)"
+        ),
+    )
     args = parser.parse_args(argv)
     return {
         "manifest": args.manifest,
@@ -152,6 +169,7 @@ def parse_args(argv: list[str] | None = None) -> dict:
         "out_dir": args.out_dir,
         "interpreter": args.interpreter,
         "manylinux": args.manylinux,
+        "maturin_bin": args.maturin_bin,
     }
 
 

--- a/scripts/stage_rust_ext.py
+++ b/scripts/stage_rust_ext.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+"""Cross-platform staging of the compiled Rust extension.
+
+Builds `rust/rs_parsers` with Maturin, then copies the resulting
+`_rs_parsers*.so` (Linux/macOS) or `_rs_parsers*.pyd` (Windows) extension
+module out of the newest built wheel and into `datamodel/rs_parsers/`, so
+that `setup.py` (via `package_data`) bundles it into the final wheel.
+
+This replaces the previous inline bash/`python3 -c` extractors used by
+`.github/workflows/release.yml` (Linux-only, `/tmp/_rs`, `.so`-only) and by
+the Makefile's `stage-rust` target. It is the single staging path shared by
+`CIBW_BEFORE_BUILD_LINUX`, `CIBW_BEFORE_BUILD_WINDOWS`, and
+`make stage-rust`.
+
+Exit status is non-zero when Maturin fails, no wheel is produced, or no
+matching extension file is found inside the wheel.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+EXTENSION_SUFFIXES = {".so", ".pyd"}
+
+
+def build_wheel(
+    manifest: str,
+    out_dir: str,
+    interpreter: str,
+    manylinux: str | None,
+) -> int:
+    """Run `maturin build --release` for `manifest`, writing to `out_dir`."""
+    command = [
+        "maturin",
+        "build",
+        "--release",
+        "--interpreter",
+        interpreter,
+        "--manifest-path",
+        manifest,
+        "--out",
+        out_dir,
+    ]
+    if manylinux is not None:
+        command.extend(["--manylinux", manylinux])
+    completed = subprocess.run(command, check=False)
+    return completed.returncode
+
+
+def _newest_wheel(out_dir: str) -> Path | None:
+    wheels = sorted(
+        Path(out_dir).glob("rs_parsers-*.whl"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    return wheels[0] if wheels else None
+
+
+def _stage_from_wheel(wheel: Path, dest: Path) -> bool:
+    """Copy every `_rs_parsers*.so`/`.pyd` member of `wheel` into `dest`.
+
+    Returns True when at least one extension file was staged.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    staged = False
+    with tempfile.TemporaryDirectory() as tmp_name:
+        tmp = Path(tmp_name)
+        with zipfile.ZipFile(wheel) as archive:
+            for member in archive.namelist():
+                # Normalize and use only the filename: never honor archive
+                # paths that could escape the staging directory.
+                name = Path(member).name
+                if not name.startswith("_rs_parsers"):
+                    continue
+                if Path(name).suffix not in EXTENSION_SUFFIXES:
+                    continue
+                extracted = archive.extract(member, path=tmp)
+                target = dest / name
+                target.write_bytes(Path(extracted).read_bytes())
+                staged = True
+    return staged
+
+
+def main(
+    manifest: str = "rust/rs_parsers/Cargo.toml",
+    dest: str = "datamodel/rs_parsers",
+    out_dir: str = "rust/target/wheels",
+    interpreter: str = "python",
+    manylinux: str | None = None,
+) -> int:
+    """Build the Rust extension and stage it into `dest`.
+
+    Returns 0 on success. Returns non-zero when Maturin fails, no wheel is
+    produced, or no `_rs_parsers*.so`/`.pyd` member is found in the wheel.
+    """
+    return_code = build_wheel(manifest, out_dir, interpreter, manylinux)
+    if return_code != 0:
+        print(f"ERROR: maturin build failed (exit {return_code})", file=sys.stderr)
+        return return_code
+
+    wheel = _newest_wheel(out_dir)
+    if wheel is None:
+        print(f"ERROR: no rs_parsers-*.whl found in {out_dir}", file=sys.stderr)
+        return 1
+
+    print(f"Staging Rust extension from {wheel}")
+    if not _stage_from_wheel(wheel, Path(dest)):
+        print(
+            f"ERROR: no _rs_parsers*.so/.pyd member found in {wheel}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> dict:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default="rust/rs_parsers/Cargo.toml",
+        help="Path to the Rust crate's Cargo.toml (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dest",
+        default="datamodel/rs_parsers",
+        help="Directory the compiled extension is copied into (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default="rust/target/wheels",
+        help="Directory maturin writes the built wheel into (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--interpreter",
+        default="python",
+        help="Target interpreter forwarded to `maturin build -i` (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--manylinux",
+        default=None,
+        help="Value forwarded to `maturin build --manylinux` (e.g. 'off'); omitted when unset",
+    )
+    args = parser.parse_args(argv)
+    return {
+        "manifest": args.manifest,
+        "dest": args.dest,
+        "out_dir": args.out_dir,
+        "interpreter": args.interpreter,
+        "manylinux": args.manylinux,
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(**parse_args()))

--- a/sdd/tasks/completed/TASK-1-uvloop-packaging-helper.md
+++ b/sdd/tasks/completed/TASK-1-uvloop-packaging-helper.md
@@ -154,7 +154,15 @@ The wheel-content assertion is completed by TASK-2.
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: <implementation and verification summary>
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-08
+**Notes**: Removed `uvloop` from `[project].dependencies`, added the
+`uvloop` optional extra with the `sys_platform != 'win32'` marker, raised
+both Cython floors to `>=3.2.8`, added `datamodel.libs` to
+`[tool.setuptools].packages`, created `datamodel/libs/uvloop.py`
+(`HAS_UVLOOP`, `install_uvloop()`) following the `rs_parsers` optional-import
+pattern, and regenerated `uv.lock` via `uv lock`. Verified the TOML
+assertions, that `datamodel.libs.uvloop` imports independently of
+`datamodel/__init__.py`, and that `import datamodel` leaves `uvloop` out of
+`sys.modules`.
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2-uvloop-helper-tests.md
+++ b/sdd/tasks/completed/TASK-2-uvloop-helper-tests.md
@@ -176,7 +176,16 @@ def test_install_uvloop_idempotent():
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: <implementation and verification summary>
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-08
+**Notes**: Created `tests/test_uvloop_helper.py` with a
+`restore_event_loop_policy` fixture, fallback/Windows-gating/activation/
+idempotency tests, a subprocess-based no-eager-import assertion, and a
+subprocess smoke test importing `datamodel.libs.uvloop` directly (packaging
+regression guard). All 6 tests pass locally with uvloop installed
+(`asyncio.new_event_loop()` yields `uvloop.Loop`); activation tests use
+`pytest.importorskip("uvloop")` so they skip cleanly when uvloop is absent.
+Ran the full suite (`pytest tests/ -v`, 251 passed) after locally building
+the Cython extensions and the Rust extension (`maturin develop --release`)
+in the worktree to match the main checkout's environment.
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-3-msvc-build-flags.md
+++ b/sdd/tasks/completed/TASK-3-msvc-build-flags.md
@@ -136,7 +136,22 @@ pure function into a small build helper module and retain the same globals.
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: <implementation and verification summary>
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-08
+**Notes**: Extracted a `_compiler_flags()` function selecting `(["/O2"], [])`
+on `win32` and `(["-O3"], ["-lstdc++"])` elsewhere, assigning
+`COMPILE_ARGS, EXTRA_LINK_ARGS = _compiler_flags()` at import time. Guarded
+the trailing `setup(...)` call behind `if __name__ == "__main__":` so
+`tests/test_setup_flags.py` can `import setup` and monkeypatch
+`setup.sys.platform` without triggering a build (this guard is the only
+deviation from the file's un-guarded original structure; behavior of
+`python setup.py build_ext[...]` is unchanged since `__main__` is still true
+when run as a script). Verified all ten extensions and the three
+`language="c++"` extensions are untouched, and rebuilt in-place locally.
+**Deviations from spec**: Added an `if __name__ == "__main__":` guard around
+the `setup()` call (not explicitly listed in the task's file table) — the
+task text anticipated this need: "If importing setup.py triggers
+unacceptable build side effects, extract the pure function into a small
+build helper module...". Guarding the call in place was simpler and kept
+the change inside `setup.py` (already in scope) instead of adding a new
+module.

--- a/sdd/tasks/completed/TASK-4-rust-staging-script.md
+++ b/sdd/tasks/completed/TASK-4-rust-staging-script.md
@@ -166,7 +166,20 @@ The tests must not require Rust or network access.
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: <implementation and verification summary>
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-08
+**Notes**: Created `scripts/stage_rust_ext.py` with `build_wheel()`,
+`main()`, and an argparse-based `parse_args()`/`__main__` CLI entrypoint
+using `subprocess`, `tempfile.TemporaryDirectory()`, `zipfile.ZipFile`, and
+`pathlib.Path` (no bash, no `/tmp` assumption). It matches
+`_rs_parsers*` members with either `.so` or `.pyd` suffix, normalizes
+archive paths to their filename only (no directory-traversal risk), and
+returns non-zero when maturin fails, no wheel is found, or no matching
+member exists. `Makefile`'s `stage-rust` now delegates to the script with
+`-i python` preserved via `--interpreter python`; the inline
+unzip/find/cp logic was removed. Added `*.pyd` to `.gitignore` beside
+`*.so`. `tests/test_stage_rust_ext.py` covers `.so` staging, `.pyd`
+staging, missing-member/missing-wheel/maturin-failure non-zero exits, the
+`--help` CLI entrypoint, and `parse_args()` option forwarding — all without
+invoking a real maturin build or requiring network access (7/7 passing).
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-5-release-workflow.md
+++ b/sdd/tasks/completed/TASK-5-release-workflow.md
@@ -158,7 +158,43 @@ output; YAML parsing alone is insufficient.
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: <implementation and workflow-run summary>
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-08
+**Notes**: Added `workflow_dispatch:` alongside `release: types: [created]`;
+added `os: [ubuntu-latest, windows-latest]` to the matrix (`fail-fast: false`
+so one OS/version failure doesn't cancel the other nine legs) crossed with
+the unchanged five-Python-version `cibw-build` include list, giving exactly
+ten build legs; `runs-on: ${{ matrix.os }}`. Set `CIBW_ARCHS_LINUX: x86_64`
+and `CIBW_ARCHS_WINDOWS: AMD64`; scoped the previous PATH override to
+`CIBW_ENVIRONMENT_LINUX` (was the OS-agnostic `CIBW_ENVIRONMENT`, which
+would have wrongly applied `/root/.cargo/bin` on Windows). Replaced the
+single `CIBW_BEFORE_BUILD` with `CIBW_BEFORE_BUILD_LINUX` (keeps the
+existing rustup curl install needed inside the manylinux container, then
+calls `scripts/stage_rust_ext.py --manylinux off` in place of the old
+inline zipfile one-liner) and `CIBW_BEFORE_BUILD_WINDOWS` (`pip install
+maturin && python scripts/stage_rust_ext.py`, relying on the
+windows-latest runner's preinstalled MSVC Rust toolchain plus the job's
+own "Install Rust"/"Add Rust to PATH" steps, exactly as sketched in the
+task). Added `CIBW_TEST_COMMAND` asserting `datamodel.rs_parsers.HAS_RUST`
+in every wheel. Dropped the explicit `--platform linux` from the
+`cibuildwheel` invocation. Artifact name is now
+`wheels-${{ matrix.os }}-py${{ matrix.python-version }}`; deploy's download
+`pattern` is `wheels-*`. Added a `Verify wheel inventory` step in `deploy`
+that fails unless `dist/` has exactly 5 manylinux x86_64 wheels, 5
+win_amd64 wheels, and 1 sdist. Verified: YAML parses cleanly; `rg` for
+`workflow_dispatch|windows-latest|CIBW_TEST_COMMAND|wheels-` matches the
+new lines; no `macos`/`arm`/`aarch64` string anywhere in the file.
+**Not verified** (cannot be done outside GitHub Actions, per the spec's own
+"No PR-time CI" risk note): an actual `workflow_dispatch` dry run showing
+all ten legs green with `HAS_RUST` true in each wheel, and the deploy
+inventory step passing against real artifacts (AC6 static structure is
+verified; AC7/AC8's live-CI assertions are not). A dispatch run on the
+pushed branch is recommended before merging, per the spec.
+**Deviations from spec**: none in workflow structure. The Linux
+`CIBW_BEFORE_BUILD_LINUX` keeps the pre-existing `curl | sh` rustup install
+that the task's abbreviated example omitted, because the manylinux
+container has no Rust preinstalled — dropping it would break the Linux
+leg entirely; the task's own Codebase Contract's "Verified Existing
+Blocks" documents this curl install as pre-existing and Module 5's scope
+is "Wire Linux staging with `--manylinux off`", not removing the
+toolchain bootstrap.

--- a/sdd/tasks/completed/TASK-6-documentation-version-changelog.md
+++ b/sdd/tasks/completed/TASK-6-documentation-version-changelog.md
@@ -139,7 +139,20 @@ python -c 'from datamodel.version import __version__; assert __version__ == "0.1
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: <implementation and verification summary>
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-08
+**Notes**: Bumped `datamodel/version.py` `__version__` to `0.11.0`. Updated
+`README.md` with supported-Python/platform wheel coverage and a new
+"Optional uvloop acceleration" section documenting the `[uvloop]` extra and
+the explicit `install_uvloop()` call. Replaced the stale
+`setuptools-rust` pip install line in `INSTALL.md` with a Maturin-based
+`make stage-rust` instruction. All grep checks from the task's Test
+Specification pass, and `__version__ == "0.11.0"`.
+**Deviations from spec**: The task's Codebase Contract listed
+`CHANGELOG.md` under "Does NOT Exist", but the file already existed at
+HEAD (pre-dating this feature, with entries up to 0.0.15) — this was a
+stale contract entry. Rather than overwrite project history, a new
+`## [0.11.0]` section was inserted above the existing `## [0.0.15]` entry,
+preserving the file's original preamble and all prior entries; this still
+satisfies AC12 ("CHANGELOG.md exists with a 0.11.0 entry and breaking
+install note").

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-08T00:00:00+00:00",
-  "completed_at": null,
+  "completed_at": "2026-09-07T23:02:23+00:00",
   "tasks": [
     {
       "id": "TASK-1",
@@ -24,7 +24,8 @@
       "updated_at": "2026-09-08T00:00:00+00:00",
       "file": "sdd/tasks/completed/TASK-1-uvloop-packaging-helper.md",
       "started_at": "2026-09-07T22:33:27+00:00",
-      "completed_at": "2026-09-07T22:36:20+00:00"
+      "completed_at": "2026-09-07T22:36:20+00:00",
+      "verification": "verified"
     },
     {
       "id": "TASK-2",
@@ -45,7 +46,8 @@
       "updated_at": "2026-09-08T00:00:00+00:00",
       "file": "sdd/tasks/completed/TASK-2-uvloop-helper-tests.md",
       "started_at": "2026-09-07T22:33:27+00:00",
-      "completed_at": "2026-09-07T22:41:40+00:00"
+      "completed_at": "2026-09-07T22:41:40+00:00",
+      "verification": "verified"
     },
     {
       "id": "TASK-3",
@@ -64,7 +66,8 @@
       "updated_at": "2026-09-08T00:00:00+00:00",
       "file": "sdd/tasks/completed/TASK-3-msvc-build-flags.md",
       "started_at": "2026-09-07T22:33:27+00:00",
-      "completed_at": "2026-09-07T22:37:48+00:00"
+      "completed_at": "2026-09-07T22:37:48+00:00",
+      "verification": "verified"
     },
     {
       "id": "TASK-4",
@@ -83,7 +86,8 @@
       "updated_at": "2026-09-08T00:00:00+00:00",
       "file": "sdd/tasks/completed/TASK-4-rust-staging-script.md",
       "started_at": "2026-09-07T22:33:27+00:00",
-      "completed_at": "2026-09-07T22:39:33+00:00"
+      "completed_at": "2026-09-07T22:39:33+00:00",
+      "verification": "verified"
     },
     {
       "id": "TASK-5",
@@ -105,7 +109,8 @@
       "updated_at": "2026-09-08T00:00:00+00:00",
       "file": "sdd/tasks/completed/TASK-5-release-workflow.md",
       "started_at": "2026-09-07T22:33:27+00:00",
-      "completed_at": "2026-09-07T22:44:09+00:00"
+      "completed_at": "2026-09-07T22:44:09+00:00",
+      "verification": "verified"
     },
     {
       "id": "TASK-6",
@@ -127,7 +132,8 @@
       "updated_at": "2026-09-08T00:00:00+00:00",
       "file": "sdd/tasks/completed/TASK-6-documentation-version-changelog.md",
       "started_at": "2026-09-07T22:33:27+00:00",
-      "completed_at": "2026-09-07T22:45:55+00:00"
+      "completed_at": "2026-09-07T22:45:55+00:00",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -13,7 +13,7 @@
       "title": "Add the optional uvloop helper and packaging constraints",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,7 +22,8 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-1-uvloop-packaging-helper.md"
+      "file": "sdd/tasks/active/TASK-1-uvloop-packaging-helper.md",
+      "started_at": "2026-09-07T22:33:27+00:00"
     },
     {
       "id": "TASK-2",
@@ -30,16 +31,19 @@
       "title": "Test uvloop fallback, activation, and wheel packaging",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "high",
       "effort": "M",
-      "depends_on": ["TASK-1"],
+      "depends_on": [
+        "TASK-1"
+      ],
       "parallel": false,
       "parallelism_notes": "Requires the helper and package inclusion from TASK-1.",
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-2-uvloop-helper-tests.md"
+      "file": "sdd/tasks/active/TASK-2-uvloop-helper-tests.md",
+      "started_at": "2026-09-07T22:33:27+00:00"
     },
     {
       "id": "TASK-3",
@@ -47,7 +51,7 @@
       "title": "Make Cython extension flags MSVC-compatible",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -56,7 +60,8 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-3-msvc-build-flags.md"
+      "file": "sdd/tasks/active/TASK-3-msvc-build-flags.md",
+      "started_at": "2026-09-07T22:33:27+00:00"
     },
     {
       "id": "TASK-4",
@@ -64,7 +69,7 @@
       "title": "Add cross-platform Rust extension staging",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -73,7 +78,8 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-4-rust-staging-script.md"
+      "file": "sdd/tasks/active/TASK-4-rust-staging-script.md",
+      "started_at": "2026-09-07T22:33:27+00:00"
     },
     {
       "id": "TASK-5",
@@ -81,16 +87,20 @@
       "title": "Add Windows and Python 3.14 release matrix coverage",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "high",
       "effort": "L",
-      "depends_on": ["TASK-3", "TASK-4"],
+      "depends_on": [
+        "TASK-3",
+        "TASK-4"
+      ],
       "parallel": false,
       "parallelism_notes": "Must follow compiler flags and shared staging script; performs the external dry run.",
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-5-release-workflow.md"
+      "file": "sdd/tasks/active/TASK-5-release-workflow.md",
+      "started_at": "2026-09-07T22:33:27+00:00"
     },
     {
       "id": "TASK-6",
@@ -98,16 +108,20 @@
       "title": "Document the install path and publish version metadata",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "medium",
       "effort": "M",
-      "depends_on": ["TASK-1", "TASK-5"],
+      "depends_on": [
+        "TASK-1",
+        "TASK-5"
+      ],
       "parallel": false,
       "parallelism_notes": "Documents final packaging and release behavior.",
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-6-documentation-version-changelog.md"
+      "file": "sdd/tasks/active/TASK-6-documentation-version-changelog.md",
+      "started_at": "2026-09-07T22:33:27+00:00"
     }
   ]
 }

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -32,7 +32,7 @@
       "title": "Test uvloop fallback, activation, and wheel packaging",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -43,8 +43,9 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-2-uvloop-helper-tests.md",
-      "started_at": "2026-09-07T22:33:27+00:00"
+      "file": "sdd/tasks/completed/TASK-2-uvloop-helper-tests.md",
+      "started_at": "2026-09-07T22:33:27+00:00",
+      "completed_at": "2026-09-07T22:41:40+00:00"
     },
     {
       "id": "TASK-3",

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -91,7 +91,7 @@
       "title": "Add Windows and Python 3.14 release matrix coverage",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -103,8 +103,9 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-5-release-workflow.md",
-      "started_at": "2026-09-07T22:33:27+00:00"
+      "file": "sdd/tasks/completed/TASK-5-release-workflow.md",
+      "started_at": "2026-09-07T22:33:27+00:00",
+      "completed_at": "2026-09-07T22:44:09+00:00"
     },
     {
       "id": "TASK-6",

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -52,7 +52,7 @@
       "title": "Make Cython extension flags MSVC-compatible",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -61,8 +61,9 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-3-msvc-build-flags.md",
-      "started_at": "2026-09-07T22:33:27+00:00"
+      "file": "sdd/tasks/completed/TASK-3-msvc-build-flags.md",
+      "started_at": "2026-09-07T22:33:27+00:00",
+      "completed_at": "2026-09-07T22:37:48+00:00"
     },
     {
       "id": "TASK-4",

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -13,7 +13,7 @@
       "title": "Add the optional uvloop helper and packaging constraints",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,9 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-1-uvloop-packaging-helper.md",
-      "started_at": "2026-09-07T22:33:27+00:00"
+      "file": "sdd/tasks/completed/TASK-1-uvloop-packaging-helper.md",
+      "started_at": "2026-09-07T22:33:27+00:00",
+      "completed_at": "2026-09-07T22:36:20+00:00"
     },
     {
       "id": "TASK-2",

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -71,7 +71,7 @@
       "title": "Add cross-platform Rust extension staging",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -80,8 +80,9 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-4-rust-staging-script.md",
-      "started_at": "2026-09-07T22:33:27+00:00"
+      "file": "sdd/tasks/completed/TASK-4-rust-staging-script.md",
+      "started_at": "2026-09-07T22:33:27+00:00",
+      "completed_at": "2026-09-07T22:39:33+00:00"
     },
     {
       "id": "TASK-5",

--- a/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
+++ b/sdd/tasks/index/new-infra-spec-uvloop-py314-windows.json
@@ -113,7 +113,7 @@
       "title": "Document the install path and publish version metadata",
       "feature_id": "FEAT-001",
       "feature": "new-infra-spec-uvloop-py314-windows",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -125,8 +125,9 @@
       "assigned_to": "unassigned",
       "created_at": "2026-09-08T00:00:00+00:00",
       "updated_at": "2026-09-08T00:00:00+00:00",
-      "file": "sdd/tasks/active/TASK-6-documentation-version-changelog.md",
-      "started_at": "2026-09-07T22:33:27+00:00"
+      "file": "sdd/tasks/completed/TASK-6-documentation-version-changelog.md",
+      "started_at": "2026-09-07T22:33:27+00:00",
+      "completed_at": "2026-09-07T22:45:55+00:00"
     }
   ]
 }

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,25 @@ See:
 https://github.com/phenobarbital/DataModel
 """
 
+import sys
+
 from Cython.Build import cythonize
 from setuptools import Extension, setup
 
-COMPILE_ARGS = ["-O3"]
-EXTRA_LINK_ARGS = ["-lstdc++"]
+
+def _compiler_flags() -> tuple[list[str], list[str]]:
+    """Select platform-appropriate compile/link flags.
+
+    MSVC (Windows) rejects the GCC-style `-O3` / `-lstdc++` flags used on
+    POSIX platforms, so this returns `/O2` with no extra link args on
+    `win32`, and the existing `-O3` / `-lstdc++` pair everywhere else.
+    """
+    if sys.platform == "win32":
+        return ["/O2"], []
+    return ["-O3"], ["-lstdc++"]
+
+
+COMPILE_ARGS, EXTRA_LINK_ARGS = _compiler_flags()
 
 extensions = [
     Extension(
@@ -78,10 +92,13 @@ extensions = [
     ),
 ]
 
-setup(
-    ext_modules=cythonize(extensions, annotate=True),
-    package_data={
-        "datamodel.rs_parsers": ["*.so", "*.pyd"],
-    },
-    zip_safe=False,
-)
+if __name__ == "__main__":
+    # Guarded so `import setup` (used by tests/test_setup_flags.py to exercise
+    # `_compiler_flags()` for both platforms) does not trigger a build.
+    setup(
+        ext_modules=cythonize(extensions, annotate=True),
+        package_data={
+            "datamodel.rs_parsers": ["*.so", "*.pyd"],
+        },
+        zip_safe=False,
+    )

--- a/tests/test_setup_flags.py
+++ b/tests/test_setup_flags.py
@@ -1,0 +1,16 @@
+"""Tests for the platform-conditional compiler flags selected in setup.py.
+
+`setup.py` guards its `setup(...)` call behind `if __name__ == "__main__":`
+so this module can be imported safely without triggering a build.
+"""
+import setup
+
+
+def test_windows_flags(monkeypatch):
+    monkeypatch.setattr(setup.sys, "platform", "win32")
+    assert setup._compiler_flags() == (["/O2"], [])
+
+
+def test_posix_flags(monkeypatch):
+    monkeypatch.setattr(setup.sys, "platform", "linux")
+    assert setup._compiler_flags() == (["-O3"], ["-lstdc++"])

--- a/tests/test_stage_rust_ext.py
+++ b/tests/test_stage_rust_ext.py
@@ -1,0 +1,115 @@
+"""Tests for `scripts/stage_rust_ext.py`.
+
+These tests never invoke a real Maturin build or need network access: the
+Maturin step is monkeypatched to a no-op, and a fake wheel zip is written
+directly into the configured `out_dir`.
+"""
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import scripts.stage_rust_ext as stage
+
+
+def _write_fake_wheel(out_dir: Path, member_name: str, content: bytes = b"payload") -> Path:
+    wheel = out_dir / "rs_parsers-0.1.0-cp312-cp312-linux_x86_64.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(f"datamodel/rs_parsers/{member_name}", content)
+    return wheel
+
+
+def test_stage_rust_ext_copies_so(tmp_path, monkeypatch):
+    out_dir = tmp_path / "wheels"
+    out_dir.mkdir()
+    dest = tmp_path / "dest"
+    _write_fake_wheel(out_dir, "_rs_parsers.cpython-312-x86_64-linux-gnu.so", b"so-bytes")
+
+    monkeypatch.setattr(stage, "build_wheel", lambda *args, **kwargs: 0)
+
+    assert stage.main(out_dir=str(out_dir), dest=str(dest)) == 0
+    staged = dest / "_rs_parsers.cpython-312-x86_64-linux-gnu.so"
+    assert staged.read_bytes() == b"so-bytes"
+
+
+def test_stage_rust_ext_copies_pyd(tmp_path, monkeypatch):
+    out_dir = tmp_path / "wheels"
+    out_dir.mkdir()
+    dest = tmp_path / "dest"
+    _write_fake_wheel(out_dir, "_rs_parsers.cp312-win_amd64.pyd", b"pyd-bytes")
+
+    monkeypatch.setattr(stage, "build_wheel", lambda *args, **kwargs: 0)
+
+    assert stage.main(out_dir=str(out_dir), dest=str(dest)) == 0
+    staged = dest / "_rs_parsers.cp312-win_amd64.pyd"
+    assert staged.read_bytes() == b"pyd-bytes"
+
+
+def test_stage_rust_ext_no_matching_member_returns_nonzero(tmp_path, monkeypatch):
+    out_dir = tmp_path / "wheels"
+    out_dir.mkdir()
+    dest = tmp_path / "dest"
+    _write_fake_wheel(out_dir, "unrelated.txt", b"nope")
+
+    monkeypatch.setattr(stage, "build_wheel", lambda *args, **kwargs: 0)
+
+    assert stage.main(out_dir=str(out_dir), dest=str(dest)) != 0
+
+
+def test_stage_rust_ext_no_wheel_returns_nonzero(tmp_path, monkeypatch):
+    out_dir = tmp_path / "wheels"
+    out_dir.mkdir()
+    dest = tmp_path / "dest"
+
+    monkeypatch.setattr(stage, "build_wheel", lambda *args, **kwargs: 0)
+
+    assert stage.main(out_dir=str(out_dir), dest=str(dest)) != 0
+
+
+def test_stage_rust_ext_maturin_failure_returns_nonzero(tmp_path, monkeypatch):
+    out_dir = tmp_path / "wheels"
+    out_dir.mkdir()
+    dest = tmp_path / "dest"
+
+    monkeypatch.setattr(stage, "build_wheel", lambda *args, **kwargs: 1)
+
+    assert stage.main(out_dir=str(out_dir), dest=str(dest)) == 1
+
+
+def test_stage_rust_ext_cli_invokes_main():
+    result = subprocess.run(
+        [sys.executable, "scripts/stage_rust_ext.py", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--manifest" in result.stdout
+    assert "--dest" in result.stdout
+    assert "--out-dir" in result.stdout
+    assert "--interpreter" in result.stdout
+    assert "--manylinux" in result.stdout
+
+
+def test_parse_args_forwards_options():
+    parsed = stage.parse_args(
+        [
+            "--manifest",
+            "custom/Cargo.toml",
+            "--dest",
+            "custom/dest",
+            "--out-dir",
+            "custom/out",
+            "--interpreter",
+            "python3.14",
+            "--manylinux",
+            "off",
+        ]
+    )
+    assert parsed == {
+        "manifest": "custom/Cargo.toml",
+        "dest": "custom/dest",
+        "out_dir": "custom/out",
+        "interpreter": "python3.14",
+        "manylinux": "off",
+    }

--- a/tests/test_stage_rust_ext.py
+++ b/tests/test_stage_rust_ext.py
@@ -104,6 +104,8 @@ def test_parse_args_forwards_options():
             "python3.14",
             "--manylinux",
             "off",
+            "--maturin-bin",
+            ".venv/bin/maturin",
         ]
     )
     assert parsed == {
@@ -112,4 +114,28 @@ def test_parse_args_forwards_options():
         "out_dir": "custom/out",
         "interpreter": "python3.14",
         "manylinux": "off",
+        "maturin_bin": ".venv/bin/maturin",
     }
+
+
+def test_stage_rust_ext_forwards_maturin_bin(tmp_path, monkeypatch):
+    """`--maturin-bin` must reach `build_wheel()` so `make stage-rust` can
+    pin the venv-local Maturin instead of resolving it via ambient PATH."""
+    out_dir = tmp_path / "wheels"
+    out_dir.mkdir()
+    dest = tmp_path / "dest"
+    _write_fake_wheel(out_dir, "_rs_parsers.cpython-312-x86_64-linux-gnu.so", b"so-bytes")
+
+    seen = {}
+
+    def fake_build_wheel(manifest, out_dir_arg, interpreter, manylinux, maturin_bin="maturin"):
+        seen["maturin_bin"] = maturin_bin
+        return 0
+
+    monkeypatch.setattr(stage, "build_wheel", fake_build_wheel)
+
+    assert (
+        stage.main(out_dir=str(out_dir), dest=str(dest), maturin_bin=".venv/bin/maturin")
+        == 0
+    )
+    assert seen["maturin_bin"] == ".venv/bin/maturin"

--- a/tests/test_uvloop_helper.py
+++ b/tests/test_uvloop_helper.py
@@ -1,0 +1,83 @@
+"""Tests for `datamodel.libs.uvloop` (`HAS_UVLOOP`, `install_uvloop()`).
+
+Missing uvloop is a supported state, not a test failure: activation tests
+skip cleanly via `pytest.importorskip("uvloop")` rather than failing when
+the optional dependency is absent.
+"""
+import asyncio
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def restore_event_loop_policy():
+    """Snapshot asyncio's policy before the test and restore it after,
+    so uvloop activation cannot leak into other tests."""
+    previous = asyncio.get_event_loop_policy()
+    try:
+        yield
+    finally:
+        asyncio.set_event_loop_policy(previous)
+
+
+def test_install_uvloop_without_uvloop_returns_false(monkeypatch):
+    import datamodel.libs.uvloop as helper
+
+    monkeypatch.setattr(helper, "HAS_UVLOOP", False)
+    assert helper.install_uvloop() is False
+
+
+def test_install_uvloop_on_win32_returns_false(monkeypatch):
+    import datamodel.libs.uvloop as helper
+
+    monkeypatch.setattr(helper.sys, "platform", "win32")
+    assert helper.install_uvloop() is False
+
+
+def test_install_uvloop_activates_policy(restore_event_loop_policy):
+    uvloop = pytest.importorskip("uvloop")
+    import datamodel.libs.uvloop as helper
+
+    assert helper.install_uvloop() is True
+    loop = asyncio.new_event_loop()
+    try:
+        assert isinstance(loop, uvloop.Loop)
+    finally:
+        loop.close()
+
+
+def test_install_uvloop_idempotent(restore_event_loop_policy):
+    pytest.importorskip("uvloop")
+    import datamodel.libs.uvloop as helper
+
+    assert helper.install_uvloop() is True
+    assert helper.install_uvloop() is True
+
+
+def test_import_datamodel_does_not_import_uvloop():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import datamodel, sys; assert 'uvloop' not in sys.modules",
+        ],
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_wheel_package_imports_uvloop_helper():
+    """Smoke-check that `datamodel.libs.uvloop` is importable as a package
+    module (guards against the packaging regression where the helper works
+    from a checkout but is absent from an installed wheel)."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from datamodel.libs.uvloop import install_uvloop, HAS_UVLOOP",
+        ],
+        check=False,
+    )
+    assert result.returncode == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,6 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "python-slugify" },
     { name = "typing-extensions" },
-    { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -1339,13 +1338,16 @@ dev = [
     { name = "ruff" },
     { name = "setuptools" },
 ]
+uvloop = [
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "ciso8601", specifier = ">=2.3.2" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "cython", marker = "extra == 'dev'", specifier = ">=3.0.11" },
+    { name = "cython", marker = "extra == 'dev'", specifier = ">=3.2.8" },
     { name = "faust-cchardet", specifier = ">=2.1.19" },
     { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
@@ -1363,9 +1365,9 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=74.0.0" },
     { name = "typing-extensions", specifier = ">=4.9.0" },
-    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
+    { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'uvloop'", specifier = ">=0.21.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["uvloop", "dev"]
 
 [[package]]
 name = "python-dateutil"


### PR DESCRIPTION
## Summary

Implements FEAT-001 — Optional uvloop, Python 3.14 build, Windows wheels.

- `uvloop` moved from a hard dependency to the optional `python-datamodel[uvloop]` extra, with an explicit opt-in `datamodel.libs.uvloop.install_uvloop()` helper (no import-time activation).
- `setup.py` now selects MSVC-compatible compiler/link flags (`/O2`, no extra link args) on `win32`, keeping `-O3`/`-lstdc++` elsewhere.
- New `scripts/stage_rust_ext.py` replaces the previous Linux-only inline extractor, staging `_rs_parsers*.so`/`.pyd` cross-platform for both `make stage-rust` and the release workflow.
- `.github/workflows/release.yml` gains a `workflow_dispatch` trigger and a `{ubuntu-latest, windows-latest} × {3.10–3.14}` matrix, a `CIBW_TEST_COMMAND` asserting `HAS_RUST`, OS-qualified artifact names, and a deploy-time wheel-inventory check.
- `README.md`/`INSTALL.md`/`CHANGELOG.md` updated; version bumped to `0.11.0`.

## Tasks

6/6 tasks verified:
  ✅ TASK-1 — Add the optional uvloop helper and packaging constraints
  ✅ TASK-2 — Test uvloop fallback, activation, and wheel packaging
  ✅ TASK-3 — Make Cython extension flags MSVC-compatible
  ✅ TASK-4 — Add cross-platform Rust extension staging
  ✅ TASK-5 — Add Windows and Python 3.14 release matrix coverage
  ✅ TASK-6 — Document the install path and publish version metadata

## Verification

- `pytest tests/ -v`: 252/252 passed locally (Cython + Rust extensions built in-worktree).
- `ruff check` clean on all new/modified files (one pre-existing, unrelated `EXE001` on `setup.py`'s shebang).
- Adversarial code review completed; 3 Important findings fixed (Windows PATH step shell, musllinux wheel filtering + strict inventory count, `make stage-rust` maturin-binary pinning), 1 suggestion fixed (softened a CHANGELOG claim), 1 suggestion + 1 nitpick noted below for the reviewer.

### Known limitation (documented, not a defect)

AC7/AC8 (a live green `workflow_dispatch` run across all 10 legs, and the deploy inventory check) cannot be exercised outside GitHub Actions. Static YAML structure, `rg` checks, and no-macOS/ARM checks all pass. **Recommend triggering a `workflow_dispatch` dry run on this branch before merging** to validate the Windows + Python 3.14 build legs end-to-end.

### Outstanding review notes (not blocking)
- 🟡 `scripts/stage_rust_ext.py` uses `--interpreter python` (previously explicit `python3`) — very likely fine under cibuildwheel's per-target venvs, but unverified on an unfamiliar image variant.
- 💡 `datamodel/libs/uvloop.py`'s `uvloop: object | None` annotation is immediately shadowed by the `try/except` import; could be simplified to match `rs_parsers.HAS_RUST`'s simpler style.

---
_Closed by /sdd-done_

## Summary by Sourcery

Prepare the package for optional uvloop usage and cross-platform Python 3.14 and Windows wheel releases.

New Features:
- Add opt-in uvloop support through the `python-datamodel[uvloop]` extra and `install_uvloop()` helper.
- Add Python 3.14 and Windows wheel coverage to the release pipeline.
- Provide cross-platform Rust extension staging for Linux and Windows builds.

Bug Fixes:
- Prevent unsupported GCC-style compiler and linker flags from being used for Windows builds.
- Ensure release artifacts include the Rust parser extension and fail validation when the expected wheel inventory is incomplete or contains unexpected wheels.

Enhancements:
- Raise the supported Python baseline to 3.10 and align Cython requirements with the new build targets.

CI:
- Expand release builds to a manually dispatchable Ubuntu and Windows matrix covering Python 3.10 through 3.14, with Rust-extension smoke tests for every wheel.

Deployment:
- Add release artifact naming by operating system and strict validation of published wheels and source distributions.

Documentation:
- Document supported Python and wheel platforms, optional uvloop installation and activation, and the Rust staging workflow.
- Add 0.11.0 release notes, including the uvloop dependency change.

Tests:
- Add coverage for uvloop fallback, explicit activation, platform handling, package inclusion, compiler flags, and cross-platform Rust extension staging.

Chores:
- Bump the package version to 0.11.0 and update packaging metadata for the new package and optional dependency.